### PR TITLE
Removed Union Types Decleration

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -84,7 +84,7 @@ final class Helpers
      * @param int $timestamp The request timestamp
      * @return array|string|object The response body
      */
-    public function sendRequest(string $method, string $path, array $body = null, int $timestamp = null): array|string|object
+    public function sendRequest(string $method, string $path, array $body = null, int $timestamp = null)
     {
         $timestamp = is_null($timestamp) ? time() : $timestamp;
         


### PR DESCRIPTION
I just removed the union type hint from line #87 because union types are not supported in PHP version<8; thus causing errors.